### PR TITLE
release: 2.7.0 — 防护页写入行为伪装 + 版本号同步

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,17 @@ edits these files for you, but they can also be inspected manually:
 - `/data/adb/pathmask/wait_seconds.conf`: total budget the boot service spends
   waiting for configured target paths to appear and (in `deny` / `allow` mode)
   for package names to resolve to UIDs. Default 60 seconds. Both phases share the
-  same deadline, so the worst-case boot delay is bounded by this value, not by
+   same deadline, so the worst-case boot delay is bounded by this value, not by
   twice it. The boot service writes its current phase to
   `/data/adb/pathmask/boot_state` so the WebUI can show whether the module is
   still waiting or has decided to skip loading.
+- `/data/adb/pathmask/write_op_policy.conf`: write-op errno policy for hidden
+  targets. `passthrough` (default) leaves write syscalls untouched so the
+  native filesystem returns stock errnos; `eacces` makes write probes see the
+  exact profile of a genuinely absent path (mkdir/Create etc. EACCES,
+  unlink/rename source ENOENT) to block existence inference; `enoent` keeps
+  the legacy blanket ENOENT. Switched from the WebUI Protection tab, which
+  persists the value and hot-reloads.
 - `/data/adb/pathmask/procguard.conf`: isolation-protection switch. Default
   `0`. `1` loads the companion `procguard.ko` at boot; the WebUI Protection
   tab writes this file and applies the change immediately.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -280,6 +280,10 @@ Scene debugfs 自动识别开关，默认 `0`（关闭）。开启后，启动�
 
 隔离防护开关，默认 `0`（停用）。填 `1` 时开机脚本会加载伴生模块 procguard.ko；在 WebUI「防护」页切换开关就是写这个文件，即时生效，不需要等重启。
 
+`/data/adb/pathmask/write_op_policy.conf`
+
+写入行为伪装策略，控制检测方对隐藏路径执行写操作（mkdir / Create / rename / 删除）时得到的错误码。`passthrough`（默认）不拦截写操作，由原生文件系统返回原厂错误码；`eacces` 让写操作返回与"路径真实不存在"一致的错误码（mkdir/Create 等返回 EACCES，删除/rename 源返回 ENOENT），阻断存在性反推；`enoent` 为旧版行为，一律返回 ENOENT。在 WebUI「防护」页切换，自动保存并热重载。
+
 `/data/adb/pathmask/boot_state`
 
 开机脚本运行到哪一阶段的状态文件，由 service.sh 自动写入：`init`、`waiting-targets`、`waiting-packages`、`loaded`、`already-loaded`、`paused`、`skipped-*`、`failed-*` 等。WebUI 健康检查会读它显示「正在等待，剩 X 秒」之类的进度，避免误以为没生效。手动改没意义，是观测用的。

--- a/kernel/pathmask.c
+++ b/kernel/pathmask.c
@@ -151,7 +151,7 @@ enum pathmask_write_op_policy {
 static char write_op_policy[16] = "passthrough";
 module_param_string(write_op_policy, write_op_policy, sizeof(write_op_policy), 0644);
 MODULE_PARM_DESC(write_op_policy,
-	"errno policy when a hidden target is hit mid write-class syscall: passthrough (default, native fs semantics), eacces, enoent (legacy)");
+	"write-class syscall policy on hidden targets: passthrough (default, native fs semantics), eacces (syscall-level absent-emulation), enoent (legacy blanket ENOENT)");
 
 static enum pathmask_write_op_policy active_write_policy = WRITE_OP_PASSTHROUGH;
 
@@ -986,6 +986,182 @@ static void unregister_syscall_hooks(void)
 	}
 }
 
+/*
+ * Write-class syscall hooks, active only with write_op_policy=eacces.
+ * The inode_permission level cannot shape mkdir/rename errno on FUSE+BPF
+ * storage: the ENOENT there is produced by Android's native package
+ * redaction during lookup and never passes through a permission check we
+ * can hook. The syscall entry stubs are the guaranteed interception point
+ * (same reasoning as the read-side fallback hooks above), so we rewrite
+ * the final errno to make a hidden-but-existing path present the exact
+ * profile of a genuinely absent one:
+ *
+ *   mkdirat / linkat / symlinkat / renameat(dst)  -> -EACCES
+ *   unlinkat / renameat(src)                      -> -ENOENT
+ */
+struct write_syscall_data {
+	bool matched;
+	long err;
+};
+
+static atomic_t pm_write_seen = ATOMIC_INIT(0);
+
+static bool sys_path_match_user_reg(struct pt_regs *regs, unsigned int regno)
+{
+	struct pt_regs *user_regs = (struct pt_regs *)regs->regs[0];
+	char buf[TARGET_TEXT_LEN];
+	long len;
+
+	if (!user_regs || !should_hide_for_current())
+		return false;
+
+	len = strncpy_from_user(buf,
+				(const char __user *)user_regs->regs[regno],
+				sizeof(buf));
+	if (len <= 0)
+		return false;
+	buf[sizeof(buf) - 1] = '\0';
+
+	return sys_path_matches_target(buf);
+}
+
+static void write_match_log_once(void)
+{
+	if (atomic_cmpxchg(&pm_write_seen, 0, 1) == 0)
+		pr_info(PM_LOG_PREFIX
+			"write-class syscall hook fired (first time)\n");
+}
+
+static int sys_mkdirat_entry(struct kretprobe_instance *ri,
+			     struct pt_regs *regs)
+{
+	struct write_syscall_data *d = (struct write_syscall_data *)ri->data;
+
+	d->matched = sys_path_match_user_reg(regs, 1);
+	d->err = -EACCES;
+	if (d->matched)
+		write_match_log_once();
+	return 0;
+}
+
+static int sys_unlinkat_entry(struct kretprobe_instance *ri,
+			      struct pt_regs *regs)
+{
+	struct write_syscall_data *d = (struct write_syscall_data *)ri->data;
+
+	d->matched = sys_path_match_user_reg(regs, 1);
+	d->err = -ENOENT;
+	if (d->matched)
+		write_match_log_once();
+	return 0;
+}
+
+/*
+ * renameat/renameat2/linkat carry two paths: oldpath in regs[1] and
+ * newpath in regs[3]. A hidden source means "absent" (-ENOENT); a hidden
+ * destination means "not writable" (-EACCES). Source wins when both hit.
+ */
+static int sys_two_path_entry(struct kretprobe_instance *ri,
+			      struct pt_regs *regs)
+{
+	struct write_syscall_data *d = (struct write_syscall_data *)ri->data;
+
+	d->matched = false;
+	d->err = 0;
+
+	if (sys_path_match_user_reg(regs, 1)) {
+		d->matched = true;
+		d->err = -ENOENT;
+	} else if (sys_path_match_user_reg(regs, 3)) {
+		d->matched = true;
+		d->err = -EACCES;
+	}
+
+	if (d->matched)
+		write_match_log_once();
+	return 0;
+}
+
+/*
+ * symlinkat(target, newdfd, linkpath): regs[1] is the symlink content
+ * string, not a lookup target; the path being created is regs[2].
+ */
+static int sys_symlinkat_entry(struct kretprobe_instance *ri,
+			       struct pt_regs *regs)
+{
+	struct write_syscall_data *d = (struct write_syscall_data *)ri->data;
+
+	d->matched = sys_path_match_user_reg(regs, 2);
+	d->err = -EACCES;
+	if (d->matched)
+		write_match_log_once();
+	return 0;
+}
+
+static int sys_write_exit(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct write_syscall_data *d = (struct write_syscall_data *)ri->data;
+
+	if (d->matched)
+		regs_set_return_value(regs, d->err);
+	return 0;
+}
+
+static struct pm_write_probe {
+	const char *symbol;
+	pm_syscall_entry_t entry;
+	struct kretprobe rp;
+	bool registered;
+} pm_write_probes[] = {
+	{ .symbol = "__arm64_sys_mkdirat",   .entry = sys_mkdirat_entry },
+	{ .symbol = "__arm64_sys_unlinkat",  .entry = sys_unlinkat_entry },
+	{ .symbol = "__arm64_sys_renameat",  .entry = sys_two_path_entry },
+	{ .symbol = "__arm64_sys_renameat2", .entry = sys_two_path_entry },
+	{ .symbol = "__arm64_sys_linkat",    .entry = sys_two_path_entry },
+	{ .symbol = "__arm64_sys_symlinkat", .entry = sys_symlinkat_entry },
+};
+
+static void register_write_hooks(void)
+{
+	unsigned int i;
+
+	for (i = 0; i < ARRAY_SIZE(pm_write_probes); i++) {
+		struct pm_write_probe *p = &pm_write_probes[i];
+		int ret;
+
+		p->rp.kp.symbol_name = p->symbol;
+		p->rp.entry_handler = p->entry;
+		p->rp.handler = sys_write_exit;
+		p->rp.data_size = sizeof(struct write_syscall_data);
+		p->rp.maxactive = 40;
+
+		ret = register_kretprobe(&p->rp);
+		if (ret) {
+			pr_warn(PM_LOG_PREFIX
+				"register_kretprobe(%s) failed: %d (skip)\n",
+				p->symbol, ret);
+			continue;
+		}
+		p->registered = true;
+		pr_info(PM_LOG_PREFIX "hooked %s (write-class)\n",
+			p->symbol);
+	}
+}
+
+static void unregister_write_hooks(void)
+{
+	unsigned int i;
+
+	for (i = 0; i < ARRAY_SIZE(pm_write_probes); i++) {
+		struct pm_write_probe *p = &pm_write_probes[i];
+
+		if (p->registered) {
+			unregister_kretprobe(&p->rp);
+			p->registered = false;
+		}
+	}
+}
+
 #define GETDENTS_BUF_LIMIT 65536u
 
 static struct kretprobe kp_getdents;
@@ -1162,7 +1338,14 @@ static int __init pathmask_init(void)
 		unsigned int wanted = parse_syscall_hooks();
 
 		if (wanted) {
-			register_syscall_hooks();
+	register_syscall_hooks();
+
+	if (active_write_policy == WRITE_OP_EACCES)
+		register_write_hooks();
+	else
+		pr_info(PM_LOG_PREFIX
+			"write-class syscall hooks disabled (write_op_policy=%s)\n",
+			write_op_policy);
 			pr_info(PM_LOG_PREFIX
 				"syscall fallback: %u of %u probe(s) requested\n",
 				wanted,
@@ -1206,6 +1389,7 @@ static void __exit pathmask_exit(void)
 	unregister_kretprobe(&kp_inode_perm);
 	unregister_kretprobe(&kp_inode_getattr);
 	unregister_syscall_hooks();
+	unregister_write_hooks();
 	if (getdents_registered) {
 		unregister_kretprobe(&kp_getdents);
 		getdents_registered = false;

--- a/kernel/pathmask.c
+++ b/kernel/pathmask.c
@@ -23,6 +23,8 @@
 #include <linux/string.h>
 #include <linux/uidgid.h>
 #include <linux/uaccess.h>
+#include <asm/syscall.h>
+#include <asm/unistd.h>
 
 #define PM_LOG_PREFIX "pathmask: "
 #define MAX_HIDE_TARGETS 64
@@ -139,6 +141,19 @@ MODULE_PARM_DESC(syscall_hooks,
 static char scope_mode[16] = "global";
 module_param_string(scope_mode, scope_mode, sizeof(scope_mode), 0644);
 MODULE_PARM_DESC(scope_mode, "Hide scope: global, deny, or allow");
+
+enum pathmask_write_op_policy {
+	WRITE_OP_PASSTHROUGH = 0,
+	WRITE_OP_EACCES,
+	WRITE_OP_ENOENT,
+};
+
+static char write_op_policy[16] = "passthrough";
+module_param_string(write_op_policy, write_op_policy, sizeof(write_op_policy), 0644);
+MODULE_PARM_DESC(write_op_policy,
+	"errno policy when a hidden target is hit mid write-class syscall: passthrough (default, native fs semantics), eacces, enoent (legacy)");
+
+static enum pathmask_write_op_policy active_write_policy = WRITE_OP_PASSTHROUGH;
 
 static char deny_uids[UID_LIST_LEN];
 module_param_string(deny_uids, deny_uids, sizeof(deny_uids), 0644);
@@ -366,6 +381,28 @@ static int parse_scope_mode(void)
 	return -EINVAL;
 }
 
+static int parse_write_op_policy(void)
+{
+	if (!strcmp(write_op_policy, "passthrough")) {
+		active_write_policy = WRITE_OP_PASSTHROUGH;
+		return 0;
+	}
+
+	if (!strcmp(write_op_policy, "eacces")) {
+		active_write_policy = WRITE_OP_EACCES;
+		return 0;
+	}
+
+	if (!strcmp(write_op_policy, "enoent")) {
+		active_write_policy = WRITE_OP_ENOENT;
+		return 0;
+	}
+
+	pr_err(PM_LOG_PREFIX "unsupported write_op_policy=%s\n",
+	       write_op_policy);
+	return -EINVAL;
+}
+
 static int add_deny_uid(uid_t uid)
 {
 	if (deny_uid_count >= MAX_DENY_UIDS) {
@@ -516,6 +553,59 @@ struct inode_perm_data {
 #define PM_PERM_INODE_REG 0
 #endif
 
+/*
+ * errno policy for write-class syscalls. inode_permission/vfs_getattr are
+ * consulted mid-operation by filesystems (FUSE+BPF does this during
+ * mkdir/rename via lookup_one_qstr_excl-style flows), so a blanket -ENOENT
+ * override leaks through as the syscall errno: mkdir on a hidden but
+ * existing directory reports ENOENT where stock returns EACCES/EEXIST --
+ * a deterministic fingerprint. passthrough (default) leaves the return
+ * value untouched so the native fs/FUSE policy produces the stock errno;
+ * parents of hidden targets are virtually never writable by the probing
+ * app, so the native result is the stock one.
+ *
+ * arm64 only ships the *at variants (no mkdir/rename/link/symlink/rmdir
+ * numbers). Kernel threads have no user pt_regs frame; treat them as
+ * non-write-class so they keep the legacy behaviour.
+ */
+static inline bool pm_is_write_class_syscall(void)
+{
+	int nr;
+
+	if (current->flags & PF_KTHREAD)
+		return false;
+
+	nr = syscall_get_nr(current, task_pt_regs(current));
+	switch (nr) {
+	case __NR_mkdirat:
+	case __NR_renameat:
+	case __NR_renameat2:
+	case __NR_linkat:
+	case __NR_symlinkat:
+	case __NR_unlinkat:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static inline void pm_apply_hide_errno(struct pt_regs *regs)
+{
+	if (pm_is_write_class_syscall()) {
+		switch (active_write_policy) {
+		case WRITE_OP_PASSTHROUGH:
+			return;
+		case WRITE_OP_EACCES:
+			regs_set_return_value(regs, -EACCES);
+			return;
+		case WRITE_OP_ENOENT:
+			break;
+		}
+	}
+
+	regs_set_return_value(regs, -ENOENT);
+}
+
 static int perm_inode_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct inode_perm_data *d = (struct inode_perm_data *)ri->data;
@@ -533,7 +623,7 @@ static int perm_exit(struct kretprobe_instance *ri, struct pt_regs *regs)
 	struct inode_perm_data *d = (struct inode_perm_data *)ri->data;
 
 	if (d->matched)
-		regs_set_return_value(regs, -ENOENT);
+		pm_apply_hide_errno(regs);
 	return 0;
 }
 
@@ -567,7 +657,7 @@ static int getattr_exit(struct kretprobe_instance *ri, struct pt_regs *regs)
 	struct inode_perm_data *d = (struct inode_perm_data *)ri->data;
 
 	if (d->matched)
-		regs_set_return_value(regs, -ENOENT);
+		pm_apply_hide_errno(regs);
 	return 0;
 }
 
@@ -1018,6 +1108,10 @@ static int __init pathmask_init(void)
 	if (ret)
 		return ret;
 
+	ret = parse_write_op_policy();
+	if (ret)
+		return ret;
+
 	ret = parse_deny_uids();
 	if (ret)
 		return ret;
@@ -1101,9 +1195,9 @@ static int __init pathmask_init(void)
 	}
 
 	pr_info(PM_LOG_PREFIX
-		"loaded -- %u target(s) hidden, scope=%s, scope_uid_count=%u hide_isolated=%d enable_syscall_hooks=%d syscall_hooks=\"%s\"\n",
+		"loaded -- %u target(s) hidden, scope=%s, scope_uid_count=%u hide_isolated=%d enable_syscall_hooks=%d syscall_hooks=\"%s\" write_op_policy=%s\n",
 		target_count, scope_mode, deny_uid_count, hide_isolated,
-		enable_syscall_hooks, syscall_hooks);
+		enable_syscall_hooks, syscall_hooks, write_op_policy);
 	return 0;
 }
 

--- a/kernel/pathmask.c
+++ b/kernel/pathmask.c
@@ -151,7 +151,7 @@ enum pathmask_write_op_policy {
 static char write_op_policy[16] = "passthrough";
 module_param_string(write_op_policy, write_op_policy, sizeof(write_op_policy), 0644);
 MODULE_PARM_DESC(write_op_policy,
-	"write-class syscall policy on hidden targets: passthrough (default, native fs semantics), eacces (syscall-level absent-emulation), enoent (legacy blanket ENOENT)");
+	"write-class syscall policy on hidden targets: passthrough (default, native fs semantics), eacces (syscall-level absent-emulation incl. open(O_CREAT)), enoent (legacy blanket ENOENT)");
 
 static enum pathmask_write_op_policy active_write_policy = WRITE_OP_PASSTHROUGH;
 
@@ -683,6 +683,7 @@ static int getattr_exit(struct kretprobe_instance *ri, struct pt_regs *regs)
 struct syscall_match_data {
 	bool matched;
 	bool needs_close;
+	long err;
 };
 
 static atomic_t pm_syscall_seen = ATOMIC_INIT(0);
@@ -747,6 +748,7 @@ static int sys_path_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	d->matched = false;
 	d->needs_close = false;
+	d->err = -ENOENT;
 
 	if (!sys_path_match_user_filename(regs))
 		return 0;
@@ -764,6 +766,7 @@ static int sys_openat_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	d->matched = false;
 	d->needs_close = false;
+	d->err = -ENOENT;
 
 	/*
 	 * For openat we can only fake -ENOENT if we also have a way to
@@ -779,9 +782,58 @@ static int sys_openat_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	d->matched = true;
 	d->needs_close = true;
+
+	/*
+	 * Under write_op_policy=eacces an open with O_CREAT must present
+	 * the absent profile (-EACCES, "create denied on a nonexistent
+	 * entry"): on FUSE+redaction storage -ENOENT here is exactly the
+	 * signature of an existing-but-hidden object. Plain opens keep
+	 * -ENOENT. Flags live in regs[2] for openat.
+	 */
+	if (active_write_policy == WRITE_OP_EACCES &&
+	    (((struct pt_regs *)regs->regs[0])->regs[2] & O_CREAT))
+		d->err = -EACCES;
+
 	if (atomic_cmpxchg(&pm_syscall_seen, 0, 1) == 0)
 		pr_info(PM_LOG_PREFIX
 			"syscall path hook fired (first time)\n");
+	return 0;
+}
+
+/*
+ * openat2 variant of the open hook: same semantics, but the flags are the
+ * first u64 of struct open_how pointed to by regs[2]. No first-fire log
+ * here; the shared pm_syscall_seen counter covers the family.
+ */
+static int sys_openat2_entry(struct kretprobe_instance *ri,
+			     struct pt_regs *regs)
+{
+	struct syscall_match_data *d = (struct syscall_match_data *)ri->data;
+	struct pt_regs *user_regs = (struct pt_regs *)regs->regs[0];
+
+	d->matched = false;
+	d->needs_close = false;
+	d->err = -ENOENT;
+
+	if (!pm_close_fd)
+		return 0;
+
+	if (!sys_path_match_user_filename(regs))
+		return 0;
+
+	d->matched = true;
+	d->needs_close = true;
+
+	if (active_write_policy == WRITE_OP_EACCES && user_regs) {
+		u64 how_flags = 0;
+
+		if (!copy_from_user(&how_flags,
+				    (const void __user *)user_regs->regs[2],
+				    sizeof(how_flags)) &&
+		    (how_flags & O_CREAT))
+			d->err = -EACCES;
+	}
+
 	return 0;
 }
 
@@ -802,7 +854,7 @@ static int sys_path_exit(struct kretprobe_instance *ri, struct pt_regs *regs)
 		pm_invoke_close_fd((unsigned int)ret);
 	}
 
-	regs_set_return_value(regs, -ENOENT);
+	regs_set_return_value(regs, d->err);
 	return 0;
 }
 
@@ -835,7 +887,7 @@ static struct pm_syscall_probe {
 	{ .symbol = "__arm64_sys_openat",     .short_name = "openat",
 	  .entry = sys_openat_entry },
 	{ .symbol = "__arm64_sys_openat2",    .short_name = "openat2",
-	  .entry = sys_openat_entry },
+	  .entry = sys_openat2_entry },
 };
 
 /*

--- a/ksu-module/module.prop
+++ b/ksu-module/module.prop
@@ -1,6 +1,6 @@
 id=pathmask
 name=PathMask 路径遮罩
-version=2.6.1
-versionCode=52
+version=2.7.0
+versionCode=53
 author=Andrea-lyz
 description=Android LKM path masking with blacklist, persistent config, WebUI diagnostics and hot reload. 安卓 LKM 路径遮罩，支持黑名单、持久化配置、WebUI 诊断和热重载。

--- a/ksu-module/service.sh
+++ b/ksu-module/service.sh
@@ -27,6 +27,7 @@ MOD_ALLOW_SYSTEM_UIDS_CONFIG="$MODDIR/allow_system_uids.conf"
 MOD_WAIT_SECONDS_CONFIG="$MODDIR/wait_seconds.conf"
 MOD_ENABLE_SYSCALL_HOOKS_CONFIG="$MODDIR/enable_syscall_hooks.conf"
 MOD_SYSCALL_HOOKS_CONFIG="$MODDIR/syscall_hooks.conf"
+MOD_WRITE_OP_POLICY_CONFIG="$MODDIR/write_op_policy.conf"
 MOD_AUTO_SCENE_DEBUGFS_CONFIG="$MODDIR/auto_scene_debugfs.conf"
 MOD_PROC_GUARD_CONFIG="$MODDIR/procguard.conf"
 
@@ -41,6 +42,7 @@ ALLOW_SYSTEM_UIDS_CONFIG="$PERSIST_DIR/allow_system_uids.conf"
 WAIT_SECONDS_CONFIG="$PERSIST_DIR/wait_seconds.conf"
 ENABLE_SYSCALL_HOOKS_CONFIG="$PERSIST_DIR/enable_syscall_hooks.conf"
 SYSCALL_HOOKS_CONFIG="$PERSIST_DIR/syscall_hooks.conf"
+WRITE_OP_POLICY_CONFIG="$PERSIST_DIR/write_op_policy.conf"
 AUTO_SCENE_DEBUGFS_CONFIG="$PERSIST_DIR/auto_scene_debugfs.conf"
 PROC_GUARD_CONFIG="$PERSIST_DIR/procguard.conf"
 SCENE_DEBUGFS_PATHS_PATH="$PERSIST_DIR/scene_debugfs_paths"
@@ -57,6 +59,7 @@ DENY_UIDS=""
 WAIT_SECONDS=60
 ENABLE_SYSCALL_HOOKS=0
 SYSCALL_HOOKS=""
+WRITE_OP_POLICY=passthrough
 AUTO_SCENE_DEBUGFS=0
 SCENE_DEBUGFS_PATHS=""
 SCENE_DEBUGFS_COUNT=0
@@ -314,6 +317,7 @@ init_persistent_config() {
 		WAIT_SECONDS_CONFIG="$MOD_WAIT_SECONDS_CONFIG"
 		ENABLE_SYSCALL_HOOKS_CONFIG="$MOD_ENABLE_SYSCALL_HOOKS_CONFIG"
 		SYSCALL_HOOKS_CONFIG="$MOD_SYSCALL_HOOKS_CONFIG"
+		WRITE_OP_POLICY_CONFIG="$MOD_WRITE_OP_POLICY_CONFIG"
 		AUTO_SCENE_DEBUGFS_CONFIG="$MOD_AUTO_SCENE_DEBUGFS_CONFIG"
 		PROC_GUARD_CONFIG="$MOD_PROC_GUARD_CONFIG"
 		return
@@ -365,6 +369,7 @@ init_persistent_config() {
 	seed_config_file "$WAIT_SECONDS_CONFIG" "$MOD_WAIT_SECONDS_CONFIG" "60"
 	seed_config_file "$ENABLE_SYSCALL_HOOKS_CONFIG" "$MOD_ENABLE_SYSCALL_HOOKS_CONFIG" "1"
 	seed_config_file "$SYSCALL_HOOKS_CONFIG" "$MOD_SYSCALL_HOOKS_CONFIG" "newfstatat,statx,faccessat2,readlinkat,openat,openat2"
+	seed_config_file "$WRITE_OP_POLICY_CONFIG" "$MOD_WRITE_OP_POLICY_CONFIG" "passthrough"
 	seed_config_file "$AUTO_SCENE_DEBUGFS_CONFIG" "$MOD_AUTO_SCENE_DEBUGFS_CONFIG" "0"
 	seed_config_file "$PROC_GUARD_CONFIG" "$MOD_PROC_GUARD_CONFIG" "0"
 
@@ -1260,6 +1265,20 @@ if [ -f "$ENABLE_SYSCALL_HOOKS_CONFIG" ]; then
 	ENABLE_SYSCALL_HOOKS="$(head -n 1 "$ENABLE_SYSCALL_HOOKS_CONFIG" | tr -d '\r ')"
 fi
 
+# write_op_policy.conf: pathmask write-class syscall policy
+# (passthrough / eacces / enoent). Passed to insmod verbatim after
+# validation; unknown values fall back to passthrough.
+if [ -f "$WRITE_OP_POLICY_CONFIG" ]; then
+	WRITE_OP_POLICY="$(head -n 1 "$WRITE_OP_POLICY_CONFIG" | tr -d '\r ')"
+fi
+case "$WRITE_OP_POLICY" in
+	passthrough|eacces|enoent) ;;
+	*)
+		log_i "unsupported write_op_policy=$WRITE_OP_POLICY, fallback to passthrough"
+		WRITE_OP_POLICY=passthrough
+		;;
+esac
+
 # syscall_hooks.conf: comma-separated allowlist of __arm64_sys_*
 # probes to register. Tolerates either a single line of tokens
 # (comma-separated) or one token per line. Empty / missing means
@@ -1427,9 +1446,9 @@ if [ -f "$PROC_GUARD_KO_PATH" ] && [ "$(head -n 1 "$PROC_GUARD_CONFIG" 2>/dev/nu
 	fi
 fi
 
-if insmod "$KO_PATH" target_paths="$TARGET_PATHS" hide_dirents="$HIDE_DIRENTS" scope_mode="$SCOPE_MODE" deny_uids="$DENY_UIDS" enable_syscall_hooks="$ENABLE_SYSCALL_HOOKS" syscall_hooks="$SYSCALL_HOOKS"; then
+if insmod "$KO_PATH" target_paths="$TARGET_PATHS" hide_dirents="$HIDE_DIRENTS" scope_mode="$SCOPE_MODE" deny_uids="$DENY_UIDS" enable_syscall_hooks="$ENABLE_SYSCALL_HOOKS" syscall_hooks="$SYSCALL_HOOKS" write_op_policy="$WRITE_OP_POLICY"; then
 	reset_load_failure_guard
-	log_i "loaded $KO_PATH target_paths=$TARGET_PATHS hide_dirents=$HIDE_DIRENTS scope_mode=$SCOPE_MODE deny_uids=$DENY_UIDS enable_syscall_hooks=$ENABLE_SYSCALL_HOOKS syscall_hooks=$SYSCALL_HOOKS"
+	log_i "loaded $KO_PATH target_paths=$TARGET_PATHS hide_dirents=$HIDE_DIRENTS scope_mode=$SCOPE_MODE deny_uids=$DENY_UIDS enable_syscall_hooks=$ENABLE_SYSCALL_HOOKS syscall_hooks=$SYSCALL_HOOKS write_op_policy=$WRITE_OP_POLICY"
 	write_boot_state "loaded" "$TARGET_PATHS" ""
 	if [ "$AUTO_SCENE_DEBUGFS" = "1" ]; then
 		write_scene_debugfs_state "$SCENE_DEBUGFS_STATUS" "1" "discovered $SCENE_DEBUGFS_COUNT matching mount(s)"

--- a/ksu-module/webroot/app.js
+++ b/ksu-module/webroot/app.js
@@ -103,6 +103,7 @@ const files = {
 	ko: `${MODDIR}/pathmask.ko`,
 	procguardKo: `${MODDIR}/procguard.ko`,
 	procguardConf: `${CONFIGDIR}/procguard.conf`,
+	writeOpPolicy: `${CONFIGDIR}/write_op_policy.conf`,
 };
 
 let apps = [];
@@ -1335,6 +1336,7 @@ true
 		dmesgState,
 		dmesgSummary,
 		sysfsParams,
+		writePolicyText: snapshot.writePolicyText || "",
 		sysResolvedCount,
 		confTargetCount: confTargets.length,
 		confSyscallHooks,
@@ -1677,6 +1679,20 @@ function buildKeyFacts(facts) {
 			"路径解析",
 			resolved >= configured ? FACT_OK : FACT_WARN,
 			`内核解析 ${resolved} / 配置 ${configured}${note}`,
+		));
+	}
+
+	// write_op_policy: the running value is the insmod-time sysfs param,
+	// the conf value is the persistent file; mismatch means the user
+	// switched the policy but has not hot-reloaded yet.
+	const writePolicyRunning = ((facts.sysfsParams || {}).write_op_policy || "").trim();
+	if (facts.moduleLoaded && writePolicyRunning) {
+		const confWritePolicy = (firstLine(facts.writePolicyText || "") || "passthrough").trim();
+		const writePolicyStale = confWritePolicy !== writePolicyRunning;
+		lines.push(fmtFactRow(
+			"写入伪装策略",
+			writePolicyStale ? FACT_WARN : FACT_OK,
+			`${writePolicyRunning}${writePolicyStale ? `（配置为 ${confWritePolicy}，未热重载）` : ""}`,
 		));
 	}
 
@@ -2078,6 +2094,7 @@ async function refreshConfig() {
 	const sysDenyUids = await safeExec(`[ -f /sys/module/${MODULE_NAME}/parameters/deny_uids ] && cat /sys/module/${MODULE_NAME}/parameters/deny_uids || true`);
 	const sysResolvedCount = await safeExec(`[ -f /sys/module/${MODULE_NAME}/parameters/resolved_count ] && cat /sys/module/${MODULE_NAME}/parameters/resolved_count || true`);
 	const procguardConfText = await readFile(files.procguardConf);
+	const writePolicyText = await readFile(files.writeOpPolicy);
 	const procguardModuleText = await safeExec(`grep '^${PROCGUARD_MODULE_NAME} ' /proc/modules || true`);
 	const procguardKoInfo = await safeExec(`[ -f ${shellQuote(files.procguardKo)} ] && echo present || echo missing`);
 	const procguardHits = await safeExec(`[ -f /sys/module/${PROCGUARD_MODULE_NAME}/parameters/blocked_hits ] && cat /sys/module/${PROCGUARD_MODULE_NAME}/parameters/blocked_hits || true`);
@@ -2099,6 +2116,10 @@ async function refreshConfig() {
 	const scope = normalizeScope(scopeText.trim() || "deny");
 	const scopeInput = document.querySelector(`input[name="scope"][value="${scope}"]`);
 	if (scopeInput) scopeInput.checked = true;
+	const writePolicyRaw = (writePolicyText || "").trim() || "passthrough";
+	const writePolicy = ["passthrough", "eacces", "enoent"].includes(writePolicyRaw) ? writePolicyRaw : "passthrough";
+	const writePolicyInput = document.querySelector(`input[name="writePolicy"][value="${writePolicy}"]`);
+	if (writePolicyInput) writePolicyInput.checked = true;
 	applyAllowSystemUidsToCheckboxes(allowSystemUidText);
 	updateAllowSystemUidsState(scope);
 	const denyPackageLines = linesFromText(denyPkgText);
@@ -2150,6 +2171,7 @@ async function refreshConfig() {
 		procguardHits,
 		procguardMissed,
 		procguardGid,
+		writePolicyText,
 		koInfo,
 		moduleFlags,
 		legacyConfigInfo,
@@ -2601,6 +2623,28 @@ async function saveConfig() {
 	showToast("已保存，重启后生效");
 }
 
+const WRITE_POLICY_LABELS = {
+	passthrough: "跟随原厂",
+	eacces: "伪装不存在",
+	enoent: "旧版行为",
+};
+
+// write_op_policy is an insmod parameter fed by service.sh from the
+// persistent conf, so switching it requires a full module reload. The
+// reload command below is intentionally kept in sync with reloadModule.
+async function applyWritePolicy() {
+	const checked = document.querySelector('input[name="writePolicy"]:checked');
+	const value = checked ? checked.value : "passthrough";
+	await writeLines(files.writeOpPolicy, [value]);
+	statusText.textContent = "正在应用写入伪装策略...";
+	const output = await execShell(
+		`if grep -q '^1' ${shellQuote(files.procguardConf)} 2>/dev/null && grep -q '^${PROCGUARD_MODULE_NAME} ' /proc/modules 2>/dev/null; then rmmod ${PROCGUARD_MODULE_NAME} 2>/dev/null || true; fi; rm -f ${shellQuote(files.sceneDebugfsWatchStop)} ${shellQuote(files.failCount)} ${shellQuote(files.failReason)} 2>/dev/null || true; if grep -q '^${MODULE_NAME} ' /proc/modules 2>/dev/null; then rmmod ${MODULE_NAME} || exit 20; fi; if grep -q '^${MODULE_NAME} ' /proc/modules 2>/dev/null; then echo 'pathmask is still loaded after rmmod' >&2; exit 21; fi; PATHMASK_RESET_FAIL_GUARD=1 PATHMASK_IGNORE_FAIL_GUARD=1 PATHMASK_INITIAL_DELAY_SECONDS=0 PATHMASK_WAIT_SECONDS=5 sh ${shellQuote(files.service)}; dmesg | grep -Ei 'pathmask|procguard|nohello|unknown symbol|invalid module|exec format|module_layout' | tail -n 30`
+	);
+	setLogContent("kernel", output);
+	await refreshDiagnostics();
+	showToast(`写入伪装已切换为「${WRITE_POLICY_LABELS[value] || value}」`);
+}
+
 async function reloadModule() {
 	await validateConfig({ throwOnError: true, requireModuleFile: true });
 	const scope = currentScope();
@@ -2977,6 +3021,9 @@ $("#procguardEnableInput").addEventListener("change", () => {
 	const enable = $("#procguardEnableInput").checked;
 	runAction(enable ? "正在启用隔离防护..." : "正在停用隔离防护...", () => setProcguardEnabled(enable)).catch(() => refreshConfig());
 });
+for (const radio of $$('input[name="writePolicy"]')) {
+	radio.addEventListener("change", () => runAction("正在应用写入伪装策略...", applyWritePolicy).catch(() => refreshConfig()));
+}
 $("#autoSceneDebugfsInput").addEventListener("change", () => {
 	const enabled = $("#autoSceneDebugfsInput").checked;
 	const node = $("#autoSceneDebugfsStatus");

--- a/ksu-module/webroot/index.html
+++ b/ksu-module/webroot/index.html
@@ -3,13 +3,13 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>PathMask v2.6.0</title>
+	<title>PathMask v2.7.0</title>
 	<link rel="stylesheet" href="./style.css">
 </head>
 <body>
 	<header class="topbar">
 		<div>
-			<h1><span>PathMask</span><small>v2.6.0</small></h1>
+			<h1><span>PathMask</span><small>v2.7.0</small></h1>
 			<p id="statusText">正在读取状态...</p>
 		</div>
 		<div class="topActions">
@@ -193,6 +193,38 @@
 					<input id="procguardEnableInput" type="checkbox">
 				</label>
 				<p id="procguardStats" class="hint">正在读取状态…</p>
+			</section>
+
+			<section class="panel">
+				<div class="sectionTitle">
+					<h2>写入行为伪装</h2>
+				</div>
+				<div class="segmented">
+					<label>
+						<input type="radio" name="writePolicy" value="passthrough">
+						<span>跟随原厂</span>
+					</label>
+					<label>
+						<input type="radio" name="writePolicy" value="eacces">
+						<span>伪装不存在</span>
+					</label>
+					<label>
+						<input type="radio" name="writePolicy" value="enoent">
+						<span>旧版行为</span>
+					</label>
+				</div>
+				<p class="hint">检测方对隐藏路径执行写操作（mkdir / Create / rename / 删除）时返回的错误码策略。切换后自动保存并热重载生效。</p>
+			</section>
+
+			<section class="panel">
+				<div class="sectionTitle">
+					<h2>写入伪装说明</h2>
+				</div>
+				<p class="hint">检测方会用写操作探测隐藏路径，并根据错误码反推路径是否存在：在 FUSE 存储上，mkdir 返回 ENOENT 恰恰是"路径存在但被隐藏"的特征，返回 EACCES 才与"路径真实不存在"一致。</p>
+				<p class="hint"><strong>跟随原厂（默认）</strong>：写操作不被拦截，由原生文件系统 / FUSE 返回原厂错误码，适合一般场景。</p>
+				<p class="hint"><strong>伪装不存在</strong>：mkdir / Create / rename 目标返回 EACCES，删除 / rename 源返回 ENOENT，与"路径真实不存在"的错误码画像完全一致，阻断存在性反推。有明确对抗检测需求时选用。</p>
+				<p class="hint"><strong>旧版行为</strong>：写操作一律返回 ENOENT，可能与原厂错误码不一致，仅为兼容旧配置保留，不建议主动选择。</p>
+				<p class="hint">验证方法：用检测工具对隐藏路径执行 mkdir，期望返回 EACCES 而非 ENOENT。边界：仅对作用范围内的 UID 生效；位于 App 可写目录（如 Documents）下的目标无法完全伪装。</p>
 			</section>
 
 			<section class="panel">

--- a/ksu-module/write_op_policy.conf
+++ b/ksu-module/write_op_policy.conf
@@ -1,0 +1,1 @@
+passthrough

--- a/update/android12-5.10.json
+++ b/update/android12-5.10.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android12-5.10_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android12-5.10_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/android13-5.10.json
+++ b/update/android13-5.10.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android13-5.10_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android13-5.10_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/android13-5.15.json
+++ b/update/android13-5.15.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android13-5.15_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android13-5.15_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/android14-5.15.json
+++ b/update/android14-5.15.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android14-5.15_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android14-5.15_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/android14-6.1.json
+++ b/update/android14-6.1.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android14-6.1_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android14-6.1_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/android15-6.6.json
+++ b/update/android15-6.6.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android15-6.6_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android15-6.6_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/android16-6.12.json
+++ b/update/android16-6.12.json
@@ -1,6 +1,6 @@
 {
-    "version":  "2.6.1",
-    "versionCode":  52,
-    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.6.1/android16-6.12_pathmask-ksu.zip",
+    "version":  "2.7.0",
+    "versionCode":  53,
+    "zipUrl":  "https://github.com/Andrea-lyz/LKM-PathMask/releases/download/v2.7.0/android16-6.12_pathmask-ksu.zip",
     "changelog":  "https://raw.githubusercontent.com/Andrea-lyz/LKM-PathMask/main/update/changelog.md"
 }

--- a/update/changelog.md
+++ b/update/changelog.md
@@ -1,3 +1,17 @@
+# PathMask 2.7.0
+
+## 解决了什么
+
+- **WebUI 防护页新增「写入行为伪装」（write_op_policy）**：跟随原厂（默认）/ 伪装不存在 / 旧版行为三选，切换自动持久化到 `write_op_policy.conf` 并立即热重载。诊断报告关键事实新增当前策略一行，配置与运行值不一致时会提示尚未热重载。
+- **「伪装不存在」策略正式可用**：检测方对隐藏路径执行 mkdir / Create / rename / 删除等写操作时，错误码被改写为与"路径真实不存在"完全一致的画像（mkdirat / linkat / symlinkat / rename 目标 / open(O_CREAT) / openat2 → EACCES，unlinkat / rename 源 → ENOENT）。在 FUSE 存储上 ENOENT 恰是"存在但被隐藏"的特征，此举切断存在性反推链。钩子位于 arm64 syscall 入口层，FUSE/BPF 原生遮蔽产生的错误码同样会被覆写。
+- **防护页新增「写入伪装说明」卡片**：三种策略的适用场景、验证方法（对隐藏路径 mkdir 应得 EACCES 而非 ENOENT）与已知边界（仅对作用范围内 UID 生效；App 可写目录下的目标无法完全伪装）。
+- **修复 WebUI 标题版本号不随 module.prop 同步的遗留问题**（2.6.x 页面一直显示 v2.6.0），此后发布统一升全部版本落点。
+
+## 其他变化
+
+- README / README.zh-CN 补充 `write_op_policy.conf` 说明。
+- 版本号统一：module.prop 2.7.0（versionCode 53）、update/*.json、WebUI 标题。
+
 # PathMask 2.6.1
 
 - **修复发布包缺失 procguard.ko**。CI 发布链路走 POSIX 版 `tools/package_ksu.sh`,上一版只拷贝了 pathmask.ko,导致 v2.6.0 的 zip 不含 procguard.ko(WebUI 防护页显示"当前模块包未包含 procguard.ko,防护不可用")。`package_ksu.sh` 现在会自动发现并打包 pathmask ko 同目录的 procguard.ko(`<base>_procguard.ko` 或 `procguard.ko`),CI 资产准备步骤同步收集 `*_procguard.ko`。


### PR DESCRIPTION
防护页新增写入行为伪装三选控件（跟随原厂/伪装不存在/旧版行为，切换即热重载）与写入伪装说明卡片；诊断报告新增策略事实；修复 WebUI 标题版本号不同步。内核侧含此前三个提交：passthrough 写类放行、syscall 级 eacces 伪装、open(O_CREAT) 覆盖。